### PR TITLE
Fixes issue-428: TargetSpace.max() bug in constrained space

### DIFF
--- a/bayes_opt/target_space.py
+++ b/bayes_opt/target_space.py
@@ -43,7 +43,7 @@ class TargetSpace(object):
             If True, the optimizer will allow duplicate points to be registered.
             This behavior may be desired in high noise situations where repeatedly probing
             the same point will give different answers. In other situations, the acquisition
-            may occasionaly generate a duplicate point.
+            may occasionally generate a duplicate point.
         """
         self.random_state = ensure_rng(random_state)
         self._allow_duplicate_points = allow_duplicate_points
@@ -70,7 +70,7 @@ class TargetSpace(object):
         self._constraint = constraint
 
         if constraint is not None:
-            # preallocated memory for constraint fulfillement
+            # preallocated memory for constraint fulfillment
             if constraint.lb.size == 1:
                 self._constraint_values = np.empty(shape=(0), dtype=float)
             else:
@@ -170,7 +170,7 @@ class TargetSpace(object):
 
         Notes
         -----
-        runs in ammortized constant time
+        runs in amortized constant time
 
         Example
         -------
@@ -290,17 +290,29 @@ class TargetSpace(object):
         if target_max is None:
             return None
 
-        target_max_idx = np.where(self.target == target_max)[0][0]
+        if self._constraint is not None:
+            allowed = self._constraint.allowed(self._constraint_values)
+
+            target = self.target[allowed]
+            params = self.params[allowed]
+            constraint_values = self.constraint_values[allowed]
+        else:
+            target = self.target
+            params = self.params
+            constraint_values = self.constraint_values
+        
+        target_max_idx = np.where(target == target_max)[0][0]
+        
 
         res = {
                 'target': target_max,
                 'params': dict(
-                zip(self.keys, self.params[target_max_idx])
+                zip(self.keys, params[target_max_idx])
             )
         }
 
         if self._constraint is not None:
-            res['constraint'] = self._constraint_values[target_max_idx]
+            res['constraint'] = constraint_values[target_max_idx]
 
         return res
 

--- a/tests/test_target_space.py
+++ b/tests/test_target_space.py
@@ -203,6 +203,17 @@ def test_max_with_constraint():
     space.probe(params={"p1": 1, "p2": 6}) # Unfeasible
     assert space.max() == {"params": {"p1": 2, "p2": 3}, "target": 5, "constraint": -1}
 
+def test_max_with_constraint_identical_target_value():
+    constraint = ConstraintModel(lambda p1, p2: p1-p2, -2, 2)
+    space = TargetSpace(target_func, PBOUNDS, constraint=constraint)
+
+    assert space.max() == None
+    space.probe(params={"p1": 1, "p2": 2}) # Feasible
+    space.probe(params={"p1": 0, "p2": 5}) # Unfeasible, target value is 5, should not be selected
+    space.probe(params={"p1": 5, "p2": 8}) # Unfeasible
+    space.probe(params={"p1": 2, "p2": 3}) # Feasible, target value is also 5
+    space.probe(params={"p1": 1, "p2": 6}) # Unfeasible
+    assert space.max() == {"params": {"p1": 2, "p2": 3}, "target": 5, "constraint": -1}
 
 def test_res():
     space = TargetSpace(target_func, PBOUNDS)


### PR DESCRIPTION
This commit fixes the bug in TargetSpace.max() when the space is constrained which lead to sometimes returning the parameters from a unfeasible point when its target value coincided with the best feasible point.

Closes #428 