### PR TITLE
bounds_transformer could bypass global_bounds due to the test logic within _trim function in domain_reduction.py

### DIFF
--- a/bayes_opt/domain_reduction.py
+++ b/bayes_opt/domain_reduction.py
@@ -106,10 +106,10 @@ class SequentialDomainReductionTransformer(DomainTransformer):
 
         # check if the new bounds exceed the global bounds
         for i, pbounds in enumerate(new_bounds):
-            # check if lower bound is in range 
+            # check if lower bound exceeds range 
             if (pbounds[0] < global_bounds[i, 0] or pbounds[0] > global_bounds[i, 1]):
                 pbounds[0] = global_bounds[i, 0]
-            # check if upper bound is in range
+            # check if upper bound exceeds range
             if (pbounds[1] > global_bounds[i, 1] or pbounds[1] < global_bounds[i, 0]):
                 pbounds[1] = global_bounds[i, 1]
      

--- a/bayes_opt/domain_reduction.py
+++ b/bayes_opt/domain_reduction.py
@@ -97,15 +97,23 @@ class SequentialDomainReductionTransformer(DomainTransformer):
         self.r = self.contraction_rate * self.r
 
     def _trim(self, new_bounds: np.array, global_bounds: np.array) -> np.array:
-        for i, variable in enumerate(new_bounds):
-            if (variable[0] < global_bounds[i, 0] or variable[0] > global_bounds[i, 1]):
-                variable[0] = global_bounds[i, 0]
-            if (variable[1] > global_bounds[i, 1] or variable[1] < global_bounds[i, 0]):
-                variable[1] = global_bounds[i, 1]
+        """ Performs tests and on the new_bounds to enforce global_bounds and minimum_window."""
+        # sort the order of the bounds for each parameter
+        for i, pbounds in enumerate(new_bounds):
+            if pbounds[0] > pbounds[1]:
+                new_bounds[i, 0] = pbounds[1]
+                new_bounds[i, 1] = pbounds[0]
+
+        # check if the new bounds exceed the global bounds
+        for i, pbounds in enumerate(new_bounds):
+            # check if lower bound is in range 
+            if (pbounds[0] < global_bounds[i, 0] or pbounds[0] > global_bounds[i, 1]):
+                pbounds[0] = global_bounds[i, 0]
+            # check if upper bound is in range
+            if (pbounds[1] > global_bounds[i, 1] or pbounds[1] < global_bounds[i, 0]):
+                pbounds[1] = global_bounds[i, 1]
+     
         for i, entry in enumerate(new_bounds):
-            if entry[0] > entry[1]:
-                new_bounds[i, 0] = entry[1]
-                new_bounds[i, 1] = entry[0]
             window_width = abs(entry[0] - entry[1])
             if window_width < self.minimum_window[i]:
                 dw = (self.minimum_window[i] - window_width) / 2.0

--- a/bayes_opt/domain_reduction.py
+++ b/bayes_opt/domain_reduction.py
@@ -134,18 +134,18 @@ class SequentialDomainReductionTransformer(DomainTransformer):
             # If a lower bound is greater than the associated global upper bound, reset it to the global lower bound
             if (pbounds[0] > global_bounds[i, 1]):
                 pbounds[0] = global_bounds[i, 0]
-                warn("""Domain Reduction Warning:
-                    A parameter's lower bound is greater than the global upper bound.
-                    The offensive boundary has been reset.
-                    Be cautious of subsequent reductions.""")
+                warn("\nDomain Reduction Warning:\n"+
+                    "A parameter's lower bound is greater than the global upper bound."+
+                    "The offensive boundary has been reset."+
+                    "Be cautious of subsequent reductions.", stacklevel=2)
 
             # If an upper bound is less than the associated global lower bound, reset it to the global upper bound
             if (pbounds[1] < global_bounds[i, 0]):
                 pbounds[1] = global_bounds[i, 1]
-                warn("""Domain reduction warning:
-                    A parameter's upper bound is less than the global lower bound.
-                    The offensive boundary has been reset.
-                    Be cautious of subsequent reductions.""")
+                warn("\nDomain Reduction Warning:\n"+
+                    "A parameter's lower bound is greater than the global upper bound."+
+                    "The offensive boundary has been reset."+
+                    "Be cautious of subsequent reductions.", stacklevel=2)
 
         # Adjust new_bounds to ensure they respect the minimum window width for each parameter
         for i, pbounds in enumerate(new_bounds):

--- a/bayes_opt/domain_reduction.py
+++ b/bayes_opt/domain_reduction.py
@@ -98,9 +98,9 @@ class SequentialDomainReductionTransformer(DomainTransformer):
 
     def _trim(self, new_bounds: np.array, global_bounds: np.array) -> np.array:
         for i, variable in enumerate(new_bounds):
-            if variable[0] < global_bounds[i, 0]:
+            if (variable[0] < global_bounds[i, 0] or variable[0] > global_bounds[i, 1]):
                 variable[0] = global_bounds[i, 0]
-            if variable[1] > global_bounds[i, 1]:
+            if (variable[1] > global_bounds[i, 1] or variable[1] < global_bounds[i, 0]):
                 variable[1] = global_bounds[i, 1]
         for i, entry in enumerate(new_bounds):
             if entry[0] > entry[1]:

--- a/bayes_opt/domain_reduction.py
+++ b/bayes_opt/domain_reduction.py
@@ -97,7 +97,7 @@ class SequentialDomainReductionTransformer(DomainTransformer):
         self.r = self.contraction_rate * self.r
 
     def _trim(self, new_bounds: np.array, global_bounds: np.array) -> np.array:
-        """ Performs tests and on the new_bounds to enforce global_bounds and minimum_window."""
+        """ Tests new_bounds to enforce global_bounds and minimum_window."""
         # sort the order of the bounds for each parameter
         for i, pbounds in enumerate(new_bounds):
             if pbounds[0] > pbounds[1]:

--- a/bayes_opt/domain_reduction.py
+++ b/bayes_opt/domain_reduction.py
@@ -2,6 +2,7 @@ from typing import Optional, Union, List
 
 import numpy as np
 from .target_space import TargetSpace
+from warnings import warn
 
 
 class DomainTransformer():
@@ -99,19 +100,23 @@ class SequentialDomainReductionTransformer(DomainTransformer):
     def _trim(self, new_bounds: np.array, global_bounds: np.array) -> np.array:
         """ Tests new_bounds to enforce global_bounds and minimum_window."""
         # sort the order of the bounds for each parameter
-        for i, pbounds in enumerate(new_bounds):
-            if pbounds[0] > pbounds[1]:
-                new_bounds[i, 0] = pbounds[1]
-                new_bounds[i, 1] = pbounds[0]
+        new_bounds = np.sort(new_bounds)
 
         # check if the new bounds exceed the global bounds
         for i, pbounds in enumerate(new_bounds):
             # check if lower bound exceeds range 
             if (pbounds[0] < global_bounds[i, 0] or pbounds[0] > global_bounds[i, 1]):
                 pbounds[0] = global_bounds[i, 0]
+                warn("""Domain reduction warning:
+                    A parameter's lower bound has exceeded its global boundaries.
+                    The offensive boundary has been reset, but the optimizer may not converge.""")
+                
             # check if upper bound exceeds range
             if (pbounds[1] > global_bounds[i, 1] or pbounds[1] < global_bounds[i, 0]):
                 pbounds[1] = global_bounds[i, 1]
+                warn("""Domain reduction warning:
+                    A parameter's upper bound has exceeded its global boundaries.
+                    The offensive boundary has been reset, but the optimizer may not converge.""")
      
         for i, entry in enumerate(new_bounds):
             window_width = abs(entry[0] - entry[1])

--- a/bayes_opt/target_space.py
+++ b/bayes_opt/target_space.py
@@ -1,4 +1,5 @@
 import numpy as np
+from warnings import warn
 from .util import ensure_rng, NotUniqueError
 from .util import Colours
 
@@ -213,6 +214,11 @@ class TargetSpace(object):
             else:
                 raise NotUniqueError(f'Data point {x} is not unique. You can set "allow_duplicate_points=True" to '
                                      f'avoid this error')
+
+        # if x is not within the bounds of the parameter space, warn the user
+        if self._bounds is not None:
+            if not np.all((self._bounds[:, 0] <= x) & (x <= self._bounds[:, 1])):
+                warn(f'\nData point {x} is outside the bounds of the parameter space. ', stacklevel=2)
 
         self._params = np.concatenate([self._params, x.reshape(1, -1)])
         self._target = np.concatenate([self._target, [target]])

--- a/bayes_opt/target_space.py
+++ b/bayes_opt/target_space.py
@@ -279,14 +279,6 @@ class TargetSpace(object):
             data.T[col] = self.random_state.uniform(lower, upper, size=1)
         return data.ravel()
 
-    def _pbound_mask(self):
-        """
-        Returns a  1D boolean mask of points that are within the bounds of the space.
-        """
-
-        return np.all((self._bounds[:, 0] <= self._params) &
-                      (self._params <= self._bounds[:, 1]), axis=1)
-
     def _target_max(self):
         """Get maximum target value found.
         

--- a/tests/test_logs_bounds.log
+++ b/tests/test_logs_bounds.log
@@ -1,0 +1,5 @@
+{"datetime": {"delta": 0.0, "datetime": "2018-11-25 08:29:25", "elapsed": 0.0}, "params": {"y": 0, "x": 0}, "target": 0}
+{"datetime": {"delta": 0.001301, "datetime": "2018-11-25 08:29:25", "elapsed": 0.001301}, "params": {"y": 1, "x": 1}, "target": 2}
+{"datetime": {"delta": 1.075242, "datetime": "2018-11-25 08:29:26", "elapsed": 1.076543}, "params": {"y": 2, "x": 2}, "target": 4}
+{"datetime": {"delta": 0.239797, "datetime": "2018-11-25 08:29:26", "elapsed": 1.31634}, "params": {"y": 3, "x": 3}, "target": 6}
+{"datetime": {"delta": 0.001301, "datetime": "2018-11-25 08:29:25", "elapsed": 0.001301}, "params": {"y": 1.5, "x": 1.5}, "target": 3}

--- a/tests/test_seq_domain_red.py
+++ b/tests/test_seq_domain_red.py
@@ -145,7 +145,7 @@ def test_exceeded_bounds():
                 bounds_transformer=bounds_transformer
             )
 
-def test_trim_both_new_bounds_beyond_gloabal_bounds():
+def test_trim_both_new_bounds_beyond_global_bounds():
     """Test if the global bounds are respected when both new bounds for a given parameter
     are beyond the global bounds."""
 
@@ -165,7 +165,6 @@ def test_trim_both_new_bounds_beyond_gloabal_bounds():
             if (pbounds[1] > global_bounds[i, 1] or pbounds[1] < global_bounds[i, 0]):
                 test = False
         return test
-
 
     # test if the sorting of the bounds is correct
     new_bounds = np.array( [[5, -5], [-10, 10]] )

--- a/tests/test_seq_domain_red.py
+++ b/tests/test_seq_domain_red.py
@@ -166,6 +166,12 @@ def test_trim_both_new_bounds_beyond_gloabal_bounds():
                 test = False
         return test
 
+
+    # test if the sorting of the bounds is correct
+    new_bounds = np.array( [[5, -5], [-10, 10]] )
+    trimmed_bounds = bounds_transformer._trim(new_bounds, global_bounds)
+    assert (trimmed_bounds == np.array( [[-5, 5], [-10, 10]] )).all()
+
     # test if both bounds for one parameter are beyond the global bounds
     new_bounds = np.array( [[-50, -20], [-10, 10]] )
     trimmed_bounds = bounds_transformer._trim(new_bounds, global_bounds)

--- a/tests/test_seq_domain_red.py
+++ b/tests/test_seq_domain_red.py
@@ -175,7 +175,7 @@ def test_trim_when_both_new_bounds_exceed_global_bounds():
     assert (trimmed_bounds == np.array( [[-5, 5], [-10, 10]] )).all()
 
     # test if both (upper/lower) bounds for a parameter exceed the global bounds
-    new_bounds = np.array( [[-50, -20], [-10, 10]] )
+    new_bounds = np.array( [[-50, -20], [20, 50]] )
     with pytest.warns(UserWarning):
         trimmed_bounds = bounds_transformer._trim(new_bounds, global_bounds)
     assert verify_bounds_in_range(trimmed_bounds, global_bounds)

--- a/tests/test_seq_domain_red.py
+++ b/tests/test_seq_domain_red.py
@@ -173,13 +173,15 @@ def test_trim_when_both_new_bounds_exceed_global_bounds():
 
     # test if both (upper/lower) bounds for a parameter exceed the global bounds
     new_bounds = np.array( [[-50, -20], [-10, 10]] )
-    trimmed_bounds = bounds_transformer._trim(new_bounds, global_bounds)
+    with pytest.warns(UserWarning):
+        trimmed_bounds = bounds_transformer._trim(new_bounds, global_bounds)
     assert verify_bounds_in_range(trimmed_bounds, global_bounds)
 
     # test if both (upper/lower) bounds for a parameter exceed the global bounds 
     # while they are out of order
     new_bounds = np.array( [[-20, -50], [-10, 10]] )
-    trimmed_bounds = bounds_transformer._trim(new_bounds, global_bounds)
+    with pytest.warns(UserWarning):
+        trimmed_bounds = bounds_transformer._trim(new_bounds, global_bounds)
     assert verify_bounds_in_range(trimmed_bounds, global_bounds)
 
 if __name__ == '__main__':

--- a/tests/test_seq_domain_red.py
+++ b/tests/test_seq_domain_red.py
@@ -145,7 +145,7 @@ def test_exceeded_bounds():
                 bounds_transformer=bounds_transformer
             )
 
-def test_trim_both_new_bounds_beyond_global_bounds():
+def test_trim_when_both_new_bounds_exceed_global_bounds():
     """Test if the global bounds are respected when both new bounds for a given parameter
     are beyond the global bounds."""
 
@@ -171,13 +171,20 @@ def test_trim_both_new_bounds_beyond_global_bounds():
     trimmed_bounds = bounds_transformer._trim(new_bounds, global_bounds)
     assert (trimmed_bounds == np.array( [[-5, 5], [-10, 10]] )).all()
 
-    # test if both bounds for one parameter are beyond the global bounds
+    # test if both (upper/lower) bounds for a parameter exceed the global bounds
     new_bounds = np.array( [[-50, -20], [-10, 10]] )
     trimmed_bounds = bounds_transformer._trim(new_bounds, global_bounds)
     assert verify_bounds_in_range(trimmed_bounds, global_bounds)
 
-    # test if both bounds for one parameter are beyond the global bounds 
+    # test if both (upper/lower) bounds for a parameter exceed the global bounds 
     # while they are out of order
     new_bounds = np.array( [[-20, -50], [-10, 10]] )
     trimmed_bounds = bounds_transformer._trim(new_bounds, global_bounds)
     assert verify_bounds_in_range(trimmed_bounds, global_bounds)
+
+if __name__ == '__main__':
+    r"""
+    CommandLine:
+        python tests/test_seq_domain_red.py
+    """
+    pytest.main([__file__])

--- a/tests/test_seq_domain_red.py
+++ b/tests/test_seq_domain_red.py
@@ -68,6 +68,7 @@ def test_bound_x_maximize():
     assert not (standard_optimizer._space.bounds ==
                 mutated_optimizer._space.bounds).any()
 
+
 def test_minimum_window_is_kept():
     bounds_transformer = SequentialDomainReductionTransformer(minimum_window=1.0)
     pbounds = {'x': (-0.5, 0.5), 'y': (-1.0, 0.0)}
@@ -105,6 +106,7 @@ def test_minimum_window_array_is_kept():
     )
     window_widths = np.diff(bounds_transformer.bounds)
     assert np.all(np.isclose(np.squeeze(np.min(window_widths, axis=0)), window_ranges))
+
 
 def test_trimming_bounds():
     """Test if the bounds are trimmed correctly within the bounds"""
@@ -144,6 +146,7 @@ def test_exceeded_bounds():
                 random_state=1,
                 bounds_transformer=bounds_transformer
             )
+
 
 def test_trim_when_both_new_bounds_exceed_global_bounds():
     """Test if the global bounds are respected when both new bounds for a given parameter

--- a/tests/test_target_space.py
+++ b/tests/test_target_space.py
@@ -189,7 +189,6 @@ def test_y_max_within_pbounds():
     assert space._target_max() == 3
 
 
-
 def test_max():
     PBOUNDS = {'p1': (0, 10), 'p2': (1, 100)}
     space = TargetSpace(target_func, PBOUNDS)

--- a/tests/test_target_space.py
+++ b/tests/test_target_space.py
@@ -182,6 +182,7 @@ def test_y_max():
     space.probe(params={"p1": 0, "p2": 1})
     assert space._target_max() == 8
 
+
 def test_y_max_with_constraint():
     PBOUNDS = {'p1': (0, 10), 'p2': (1, 100)}
     constraint = ConstraintModel(lambda p1, p2: p1-p2, -2, 2)
@@ -191,6 +192,7 @@ def test_y_max_with_constraint():
     space.probe(params={"p1": 5, "p2": 1}) # Unfeasible
     space.probe(params={"p1": 0, "p2": 1}) # Feasible
     assert space._target_max() == 3
+
 
 def test_y_max_within_pbounds():
     PBOUNDS = {'p1': (0, 2), 'p2': (1, 100)}
@@ -214,6 +216,7 @@ def test_max():
     space.probe(params={"p1": 1, "p2": 6})
     assert space.max() == {"params": {"p1": 5, "p2": 4}, "target": 9}
 
+
 def test_max_with_constraint():
     PBOUNDS = {'p1': (0, 10), 'p2': (1, 100)}
     constraint = ConstraintModel(lambda p1, p2: p1-p2, -2, 2)
@@ -225,6 +228,7 @@ def test_max_with_constraint():
     space.probe(params={"p1": 2, "p2": 3}) # Feasible
     space.probe(params={"p1": 1, "p2": 6}) # Unfeasible
     assert space.max() == {"params": {"p1": 2, "p2": 3}, "target": 5, "constraint": -1}
+
 
 def test_max_with_constraint_identical_target_value():
     PBOUNDS = {'p1': (0, 10), 'p2': (1, 100)}
@@ -238,6 +242,7 @@ def test_max_with_constraint_identical_target_value():
     space.probe(params={"p1": 2, "p2": 3}) # Feasible, target value is also 5
     space.probe(params={"p1": 1, "p2": 6}) # Unfeasible
     assert space.max() == {"params": {"p1": 2, "p2": 3}, "target": 5, "constraint": -1}
+
 
 def test_res():
     PBOUNDS = {'p1': (0, 10), 'p2': (1, 100)}

--- a/tests/test_target_space.py
+++ b/tests/test_target_space.py
@@ -166,10 +166,10 @@ def test_random_sample():
 def test_y_max():
     space = TargetSpace(target_func, PBOUNDS)
     assert space._target_max() == None
-    space.probe(params={"p1": 1, "p2": 2})
-    space.probe(params={"p1": 5, "p2": 1})
+    space.probe(params={"p1": 1, "p2": 7})
+    space.probe(params={"p1": 0.5, "p2": 1})
     space.probe(params={"p1": 0, "p2": 1})
-    assert space._target_max() == 6
+    assert space._target_max() == 8
 
 def test_y_max_with_constraint():
     constraint = ConstraintModel(lambda p1, p2: p1-p2, -2, 2)
@@ -180,11 +180,20 @@ def test_y_max_with_constraint():
     space.probe(params={"p1": 0, "p2": 1}) # Feasible
     assert space._target_max() == 3
 
+def test_y_max_within_pbounds():
+    space = TargetSpace(target_func, PBOUNDS)
+    assert space._target_max() == None
+    space.probe(params={"p1": 1, "p2": 2})
+    space.probe(params={"p1": 5, "p2": 1})
+    space.probe(params={"p1": 0, "p2": 1})
+    assert space._target_max() == 3
+
 
 
 def test_max():
+    PBOUNDS = {'p1': (0, 10), 'p2': (1, 100)}
     space = TargetSpace(target_func, PBOUNDS)
-
+    
     assert space.max() == None
     space.probe(params={"p1": 1, "p2": 2})
     space.probe(params={"p1": 5, "p2": 4})
@@ -193,6 +202,7 @@ def test_max():
     assert space.max() == {"params": {"p1": 5, "p2": 4}, "target": 9}
 
 def test_max_with_constraint():
+    PBOUNDS = {'p1': (0, 10), 'p2': (1, 100)}
     constraint = ConstraintModel(lambda p1, p2: p1-p2, -2, 2)
     space = TargetSpace(target_func, PBOUNDS, constraint=constraint)
 
@@ -204,6 +214,7 @@ def test_max_with_constraint():
     assert space.max() == {"params": {"p1": 2, "p2": 3}, "target": 5, "constraint": -1}
 
 def test_max_with_constraint_identical_target_value():
+    PBOUNDS = {'p1': (0, 10), 'p2': (1, 100)}
     constraint = ConstraintModel(lambda p1, p2: p1-p2, -2, 2)
     space = TargetSpace(target_func, PBOUNDS, constraint=constraint)
 

--- a/tests/test_target_space.py
+++ b/tests/test_target_space.py
@@ -74,6 +74,7 @@ def test_as_array():
 
 
 def test_register():
+    PBOUNDS = {'p1': (0, 10), 'p2': (1, 100)}
     space = TargetSpace(target_func, PBOUNDS)
 
     assert len(space) == 0
@@ -96,6 +97,7 @@ def test_register():
 
 
 def test_register_with_constraint():
+    PBOUNDS = {'p1': (0, 10), 'p2': (1, 100)}
     constraint = ConstraintModel(lambda x: x, -2, 2)
     space = TargetSpace(target_func, PBOUNDS, constraint=constraint)
 
@@ -118,7 +120,16 @@ def test_register_with_constraint():
         space.register(params={"p1": 2, "p2": 2}, target=3)
 
 
+def test_register_point_beyond_bounds():
+    PBOUNDS = {'p1': (0, 1), 'p2': (1, 10)}
+    space = TargetSpace(target_func, PBOUNDS)
+
+    with pytest.warns(UserWarning):
+        space.register(params={"p1": 0.5, "p2": 20}, target=2.5)
+
+
 def test_probe():
+    PBOUNDS = {'p1': (0, 10), 'p2': (1, 100)}
     space = TargetSpace(target_func, PBOUNDS, allow_duplicate_points=True)
 
     assert len(space) == 0
@@ -172,6 +183,7 @@ def test_y_max():
     assert space._target_max() == 8
 
 def test_y_max_with_constraint():
+    PBOUNDS = {'p1': (0, 10), 'p2': (1, 100)}
     constraint = ConstraintModel(lambda p1, p2: p1-p2, -2, 2)
     space = TargetSpace(target_func, PBOUNDS, constraint)
     assert space._target_max() == None
@@ -181,11 +193,13 @@ def test_y_max_with_constraint():
     assert space._target_max() == 3
 
 def test_y_max_within_pbounds():
+    PBOUNDS = {'p1': (0, 2), 'p2': (1, 100)}
     space = TargetSpace(target_func, PBOUNDS)
     assert space._target_max() == None
     space.probe(params={"p1": 1, "p2": 2})
-    space.probe(params={"p1": 5, "p2": 1})
     space.probe(params={"p1": 0, "p2": 1})
+    with pytest.warns(UserWarning):
+        space.probe(params={"p1": 5, "p2": 1})
     assert space._target_max() == 3
 
 
@@ -226,6 +240,7 @@ def test_max_with_constraint_identical_target_value():
     assert space.max() == {"params": {"p1": 2, "p2": 3}, "target": 5, "constraint": -1}
 
 def test_res():
+    PBOUNDS = {'p1': (0, 10), 'p2': (1, 100)}
     space = TargetSpace(target_func, PBOUNDS)
 
     assert space.res() == []

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -132,7 +132,7 @@ def test_logs():
 
     optimizer = BayesianOptimization(
         f=f,
-        pbounds={"x": (-2, 2), "y": (-2, 2)}
+        pbounds={"x": (-200, 200), "y": (-200, 200)}
     )
     assert len(optimizer.space) == 0
 
@@ -150,6 +150,21 @@ def test_logs():
         load_logs(other_optimizer, [str(test_dir / "test_logs.log")])
 
 
+def test_logs_bounds():
+    def f(x, y):
+        return x + y
+
+    optimizer = BayesianOptimization(
+        f=f,
+        pbounds={"x": (-2, 2), "y": (-2, 2)}
+    )
+
+    with pytest.warns(UserWarning):
+        load_logs(optimizer, [str(test_dir / "test_logs_bounds.log")])
+    
+    assert len(optimizer.space) == 5
+
+
 def test_logs_constraint():
 
     def f(x, y):
@@ -162,7 +177,7 @@ def test_logs_constraint():
 
     optimizer = BayesianOptimization(
         f=f,
-        pbounds={"x": (-2, 2), "y": (-2, 2)},
+        pbounds={"x": (-200, 200), "y": (-200, 200)},
         constraint=constraint
     )
 
@@ -201,5 +216,4 @@ if __name__ == '__main__':
     CommandLine:
         python tests/test_target_space.py
     """
-    import pytest
     pytest.main([__file__])


### PR DESCRIPTION
Previously, when the upper limit of  new_bounds < lower limit of global_bounds, the new_bounds could bypass the global_bounds.  The proposed changes requires the little change to the existing code, but could cause one of the entries in new_bounds to stagnate at the global_bounds if the new_bounds entry is always outside of the global_bounds.