### PR TITLE
docs: Add acquisition functions

### DIFF
--- a/bayes_opt/acquisition.py
+++ b/bayes_opt/acquisition.py
@@ -12,23 +12,7 @@ from sklearn.gaussian_process import GaussianProcessRegressor
 from typing import Callable, List, Union, Tuple
 from copy import deepcopy
 from numbers import Number
-
-class ConstraintNotSupportedError(Exception):
-    """Raised when constrained optimization is not supported."""
-
-    pass
-
-
-class NoValidPointRegisteredError(Exception):
-    """Raised when an acquisition function depends on previous points but none are registered."""
-
-    pass
-
-
-class TargetSpaceEmptyError(Exception):
-    """Raised when the target space is empty."""
-
-    pass
+from .util import ConstraintNotSupportedError, NoValidPointRegisteredError, TargetSpaceEmptyError
 
 
 class AcquisitionFunction(abc.ABC):

--- a/bayes_opt/util.py
+++ b/bayes_opt/util.py
@@ -7,6 +7,24 @@ class NotUniqueError(Exception):
     """A point is non-unique."""
 
 
+class ConstraintNotSupportedError(Exception):
+    """Raised when constrained optimization is not supported."""
+
+    pass
+
+
+class NoValidPointRegisteredError(Exception):
+    """Raised when an acquisition function depends on previous points but none are registered."""
+
+    pass
+
+
+class TargetSpaceEmptyError(Exception):
+    """Raised when the target space is empty."""
+
+    pass
+
+
 def load_logs(optimizer, logs):
     """Load previous ...
 

--- a/docsrc/code_docs.rst
+++ b/docsrc/code_docs.rst
@@ -9,10 +9,10 @@ Bayesian Optimization
 .. automodule:: bayes_opt.bayesian_optimization
    :members:
 
-Acquisition function
---------------------
+Acquisition Functions
+---------------------
 
-.. autoclass:: bayes_opt.util.UtilityFunction
+.. automodule:: bayes_opt.acquisition
    :members:
 
 Target Space

--- a/docsrc/examples.rst
+++ b/docsrc/examples.rst
@@ -8,6 +8,7 @@ Examples
    /basic-tour
    /advanced-tour
    /exploitation_vs_exploration
+   /acquisition_functions
    /visualization
    /constraints
    /domain_reduction


### PR DESCRIPTION
I knew I had forgotten something in the original PR!
- adds the `acquisition.py` module to the code docs
- adds the `acquisition_functions.ipynb` notebook to the docs
- moves exceptions from `acquisition.py` to `util.py` (where `NotUniqueError` was already defined)