### PR TITLE
fix docs for `TargetSpace.random_sample`

### DIFF
--- a/bayes_opt/target_space.py
+++ b/bayes_opt/target_space.py
@@ -395,7 +395,7 @@ class TargetSpace():
         >>> pbounds = {'p1': (0, 1), 'p2': (1, 100)}
         >>> space = TargetSpace(target_func, pbounds, random_state=0)
         >>> space.random_sample()
-        array([[ 55.33253689,   0.54488318]])
+        array([[ 0.54488318,   55.33253689]])
         """
         data = np.empty((1, self.dim))
         for col, (lower, upper) in enumerate(self._bounds):


### PR DESCRIPTION
The example sampling results in the comments of the `random_sample()` function in the `target_space.py` file may have been written backwards.
```python
Examples
        --------
        >>> target_func = lambda p1, p2: p1 + p2
        >>> pbounds = {'p1': (0, 1), 'p2': (1, 100)}
        >>> space = TargetSpace(target_func, pbounds, random_state=0)
        >>> space.random_sample()
        array([[ 55.33253689,   0.54488318]])
```

It should be amended to:
```python
Examples
        --------
        >>> target_func = lambda p1, p2: p1 + p2
        >>> pbounds = {'p1': (0, 1), 'p2': (1, 100)}
        >>> space = TargetSpace(target_func, pbounds, random_state=0)
        >>> space.random_sample()
        array([[0.54488318 ,   55.33253689]])
```
The example may mislead users.
