### PR TITLE
docs: replace " : " with ": "

### DIFF
--- a/bayes_opt/acquisition.py
+++ b/bayes_opt/acquisition.py
@@ -27,7 +27,7 @@ class AcquisitionFunction(abc.ABC):
 
     Parameters
     ----------
-    random_state : int, RandomState, default None
+    random_state: int, RandomState, default None
         Set the random state for reproducibility.
     """
 
@@ -66,19 +66,19 @@ class AcquisitionFunction(abc.ABC):
 
         Parameters
         ----------
-        gp : GaussianProcessRegressor
+        gp: GaussianProcessRegressor
             A fitted Gaussian Process.
 
-        target_space : TargetSpace
+        target_space: TargetSpace
             The target space to probe.
 
-        n_random : int, default 10_000
+        n_random: int, default 10_000
             Number of random samples to use.
 
-        n_l_bfgs_b : int, default 10
+        n_l_bfgs_b: int, default 10
             Number of starting points for the L-BFGS-B optimizer.
 
-        fit_gp : bool, default True
+        fit_gp: bool, default True
             Whether to fit the Gaussian Process to the target space.
             Set to False if the GP is already fitted.
 
@@ -111,10 +111,10 @@ class AcquisitionFunction(abc.ABC):
 
         Parameters
         ----------
-        gp : GaussianProcessRegressor
+        gp: GaussianProcessRegressor
             A fitted Gaussian Process.
 
-        constraint : ConstraintModel, default None
+        constraint: ConstraintModel, default None
             A fitted constraint model, if constraints are present and the
             acquisition function supports them.
 
@@ -153,18 +153,18 @@ class AcquisitionFunction(abc.ABC):
 
         Parameters
         ----------
-        acq : Callable
+        acq: Callable
             Acquisition function to use. Should accept an array of parameters `x`.
 
-        bounds : np.ndarray
+        bounds: np.ndarray
             Bounds of the search space. For `N` parameters this has shape
             `(N, 2)` with `[i, 0]` the lower bound of parameter `i` and
             `[i, 1]` the upper bound.
 
-        n_random : int
+        n_random: int
             Number of random samples to use.
 
-        n_l_bfgs_b : int
+        n_l_bfgs_b: int
             Number of starting points for the L-BFGS-B optimizer.
 
         Returns
@@ -189,23 +189,23 @@ class AcquisitionFunction(abc.ABC):
 
         Parameters
         ----------
-        acq : Callable
+        acq: Callable
             Acquisition function to use. Should accept an array of parameters `x`.
 
-        bounds : np.ndarray
+        bounds: np.ndarray
             Bounds of the search space. For `N` parameters this has shape
             `(N, 2)` with `[i, 0]` the lower bound of parameter `i` and
             `[i, 1]` the upper bound.
 
-        n_random : int
+        n_random: int
             Number of random samples to use.
 
         Returns
         -------
-        x_min : np.ndarray
+        x_min: np.ndarray
             Random sample minimizing the acquisition function.
 
-        min_acq : float
+        min_acq: float
             Acquisition function value at `x_min`
         """
         if n_random == 0:
@@ -223,23 +223,23 @@ class AcquisitionFunction(abc.ABC):
 
         Parameters
         ----------
-        acq : Callable
+        acq: Callable
             Acquisition function to use. Should accept an array of parameters `x`.
 
-        bounds : np.ndarray
+        bounds: np.ndarray
             Bounds of the search space. For `N` parameters this has shape
             `(N, 2)` with `[i, 0]` the lower bound of parameter `i` and
             `[i, 1]` the upper bound.
 
-        n_x_seeds : int
+        n_x_seeds: int
             Number of starting points for the L-BFGS-B optimizer.
 
         Returns
         -------
-        x_min : np.ndarray
+        x_min: np.ndarray
             Minimal result of the L-BFGS-B optimizer.
 
-        min_acq : float
+        min_acq: float
             Acquisition function value at `x_min`
         """
         if n_x_seeds == 0:
@@ -279,17 +279,17 @@ class UpperConfidenceBound(AcquisitionFunction):
 
     Parameters
     ----------
-    kappa : float, default 2.576
+    kappa: float, default 2.576
         Governs the exploration/exploitation tradeoff. Lower prefers
         exploitation, higher prefers exploration.
 
-    exploration_decay : float, default None
+    exploration_decay: float, default None
         Decay rate for kappa. If None, no decay is applied.
 
-    exploration_decay_delay : int, default None
+    exploration_decay_delay: int, default None
         Delay for decay. If None, decay is applied from the start.
 
-    random_state : int, RandomState, default None
+    random_state: int, RandomState, default None
         Set the random state for reproducibility.
 
     """
@@ -311,10 +311,10 @@ class UpperConfidenceBound(AcquisitionFunction):
 
         Parameters
         ----------
-        mean : np.ndarray
+        mean: np.ndarray
             Mean of the predictive distribution.
 
-        std : np.ndarray
+        std: np.ndarray
             Standard deviation of the predictive distribution.
 
         Returns
@@ -336,19 +336,19 @@ class UpperConfidenceBound(AcquisitionFunction):
 
         Parameters
         ----------
-        gp : GaussianProcessRegressor
+        gp: GaussianProcessRegressor
             A fitted Gaussian Process.
 
-        target_space : TargetSpace
+        target_space: TargetSpace
             The target space to probe.
 
-        n_random : int, default 10_000
+        n_random: int, default 10_000
             Number of random samples to use.
 
-        n_l_bfgs_b : int, default 10
+        n_l_bfgs_b: int, default 10
             Number of starting points for the L-BFGS-B optimizer.
 
-        fit_gp : bool, default True
+        fit_gp: bool, default True
             Whether to fit the Gaussian Process to the target space.
             Set to False if the GP is already fitted.
 
@@ -391,17 +391,17 @@ class ProbabilityOfImprovement(AcquisitionFunction):
 
     Parameters
     ----------
-    xi : float, positive
+    xi: float, positive
         Governs the exploration/exploitation tradeoff. Lower prefers
         exploitation, higher prefers exploration.
 
-    exploration_decay : float, default None
+    exploration_decay: float, default None
         Decay rate for xi. If None, no decay is applied.
 
-    exploration_decay_delay : int, default None
+    exploration_decay_delay: int, default None
         Delay for decay. If None, decay is applied from the start.
 
-    random_state : int, RandomState, default None
+    random_state: int, RandomState, default None
         Set the random state for reproducibility.
     """
 
@@ -417,10 +417,10 @@ class ProbabilityOfImprovement(AcquisitionFunction):
 
         Parameters
         ----------
-        mean : np.ndarray
+        mean: np.ndarray
             Mean of the predictive distribution.
 
-        std : np.ndarray
+        std: np.ndarray
             Standard deviation of the predictive distribution.
 
         Returns
@@ -454,19 +454,19 @@ class ProbabilityOfImprovement(AcquisitionFunction):
 
         Parameters
         ----------
-        gp : GaussianProcessRegressor
+        gp: GaussianProcessRegressor
             A fitted Gaussian Process.
 
-        target_space : TargetSpace
+        target_space: TargetSpace
             The target space to probe.
 
-        n_random : int, default 10_000
+        n_random: int, default 10_000
             Number of random samples to use.
 
-        n_l_bfgs_b : int, default 10
+        n_l_bfgs_b: int, default 10
             Number of starting points for the L-BFGS-B optimizer.
 
-        fit_gp : bool, default True
+        fit_gp: bool, default True
             Whether to fit the Gaussian Process to the target space.
             Set to False if the GP is already fitted.
 
@@ -520,16 +520,16 @@ class ExpectedImprovement(AcquisitionFunction):
 
     Parameters
     ----------
-    xi : float, positive
+    xi: float, positive
         Governs the exploration/exploitation tradeoff. Lower prefers
         exploitation, higher prefers exploration.
 
-    exploration_decay : float, default None
+    exploration_decay: float, default None
         Decay rate for xi. If None, no decay is applied.
 
-    exploration_decay_delay : int, default None
+    exploration_decay_delay: int, default None
 
-    random_state : int, RandomState, default None
+    random_state: int, RandomState, default None
         Set the random state for reproducibility.
     """
 
@@ -545,10 +545,10 @@ class ExpectedImprovement(AcquisitionFunction):
 
         Parameters
         ----------
-        mean : np.ndarray
+        mean: np.ndarray
             Mean of the predictive distribution.
 
-        std : np.ndarray
+        std: np.ndarray
             Standard deviation of the predictive distribution.
 
         Returns
@@ -583,19 +583,19 @@ class ExpectedImprovement(AcquisitionFunction):
 
         Parameters
         ----------
-        gp : GaussianProcessRegressor
+        gp: GaussianProcessRegressor
             A fitted Gaussian Process.
 
-        target_space : TargetSpace
+        target_space: TargetSpace
             The target space to probe.
 
-        n_random : int, default 10_000
+        n_random: int, default 10_000
             Number of random samples to use.
 
-        n_l_bfgs_b : int, default 10
+        n_l_bfgs_b: int, default 10
             Number of starting points for the L-BFGS-B optimizer.
 
-        fit_gp : bool, default True
+        fit_gp: bool, default True
             Whether to fit the Gaussian Process to the target space.
             Set to False if the GP is already fitted.
 
@@ -644,22 +644,22 @@ class ConstantLiar(AcquisitionFunction):
 
     Parameters
     ----------
-    base_acquisition : AcquisitionFunction
+    base_acquisition: AcquisitionFunction
         The acquisition function to use.
 
-    strategy : float or str, default 'max'
+    strategy: float or str, default 'max'
         Strategy to use for the constant liar. If a float, the constant liar
         will always register dummies with this value. If 'min'/'mean'/'max',
         the constant liar will register dummies with the minimum/mean/maximum
         target value in the target space.
 
-    random_state : int, RandomState, default None
+    random_state: int, RandomState, default None
         Set the random state for reproducibility.
 
-    atol : float, default 1e-5
+    atol: float, default 1e-5
         Absolute tolerance to eliminate a dummy point.
 
-    rtol : float, default 1e-8
+    rtol: float, default 1e-8
         Relative tolerance to eliminate a dummy point.
     """
 
@@ -693,7 +693,7 @@ class ConstantLiar(AcquisitionFunction):
 
         Parameters
         ----------
-        target_space : TargetSpace
+        target_space: TargetSpace
             The target space to copy.
 
         Returns
@@ -723,7 +723,7 @@ class ConstantLiar(AcquisitionFunction):
 
         Parameters
         ----------
-        target_space : TargetSpace
+        target_space: TargetSpace
             The target space to compare the dummies to.
         """
         dummies = []
@@ -745,19 +745,19 @@ class ConstantLiar(AcquisitionFunction):
 
         Parameters
         ----------
-        gp : GaussianProcessRegressor
+        gp: GaussianProcessRegressor
             A fitted Gaussian Process.
 
-        target_space : TargetSpace
+        target_space: TargetSpace
             The target space to probe.
 
-        n_random : int, default 10_000
+        n_random: int, default 10_000
             Number of random samples to use.
 
-        n_l_bfgs_b : int, default 10
+        n_l_bfgs_b: int, default 10
             Number of starting points for the L-BFGS-B optimizer.
 
-        fit_gp : bool, default True
+        fit_gp: bool, default True
             Whether to fit the Gaussian Process to the target space.
             Set to False if the GP is already fitted.
 
@@ -831,10 +831,10 @@ class GPHedge(AcquisitionFunction):
 
     Parameters
     ----------
-    base_acquisitions : List[AcquisitionFunction]
+    base_acquisitions: List[AcquisitionFunction]
         List of base acquisition functions.
 
-    random_state : int, RandomState, default None
+    random_state: int, RandomState, default None
         Set the random state for reproducibility.
     """
 
@@ -880,19 +880,19 @@ class GPHedge(AcquisitionFunction):
 
         Parameters
         ----------
-        gp : GaussianProcessRegressor
+        gp: GaussianProcessRegressor
             A fitted Gaussian Process.
 
-        target_space : TargetSpace
+        target_space: TargetSpace
             The target space to probe.
 
-        n_random : int, default 10_000
+        n_random: int, default 10_000
             Number of random samples to use.
 
-        n_l_bfgs_b : int, default 10
+        n_l_bfgs_b: int, default 10
             Number of starting points for the L-BFGS-B optimizer.
 
-        fit_gp : bool, default True
+        fit_gp: bool, default True
             Whether to fit the Gaussian Process to the target space.
             Set to False if the GP is already fitted.
 

--- a/bayes_opt/bayesian_optimization.py
+++ b/bayes_opt/bayesian_optimization.py
@@ -302,7 +302,7 @@ class BayesianOptimization(Observable):
 
         Parameters
         ----------
-        init_points : int, optional(default=5)
+        init_points: int, optional(default=5)
             Number of iterations before the explorations starts the exploration
             for the maximum.
 
@@ -335,7 +335,7 @@ class BayesianOptimization(Observable):
 
         Parameters
         ----------
-        new_bounds : dict
+        new_bounds: dict
             A dictionary with the parameter name and its new bounds
         """
         self._space.set_bounds(new_bounds)

--- a/bayes_opt/constraint.py
+++ b/bayes_opt/constraint.py
@@ -17,20 +17,20 @@ class ConstraintModel:
 
     Parameters
     ----------
-    fun : None or Callable -> float or np.ndarray
+    fun: None or Callable -> float or np.ndarray
         The constraint function. Should be float-valued or array-valued (if
         multiple constraints are present). Needs to take the same parameters
         as the optimization target with the same argument names.
 
-    lb : float or np.ndarray
+    lb: float or np.ndarray
         The lower bound on the constraints. Should have the same
         dimensionality as the return value of the constraint function.
 
-    ub : float or np.ndarray
+    ub: float or np.ndarray
         The upper bound on the constraints. Should have the same
         dimensionality as the return value of the constraint function.
 
-    random_state : np.random.RandomState or int or None, default=None
+    random_state: np.random.RandomState or int or None, default=None
         Random state to use.
 
     Notes
@@ -82,7 +82,7 @@ class ConstraintModel:
 
         Parameters
         ----------
-        \*\*kwargs : any
+        \*\*kwargs: any
             Function arguments to evaluate the constraint function on.
 
 
@@ -152,7 +152,7 @@ class ConstraintModel:
 
         Parameters
         ----------
-        X : np.ndarray of shape (n_samples, n_features)
+        X: np.ndarray of shape (n_samples, n_features)
             Parameters for which to predict the probability of constraint
             fulfilment.
 
@@ -195,7 +195,7 @@ class ConstraintModel:
 
         Parameters
         ----------
-        X : np.ndarray of shape (n_samples, n_features)
+        X: np.ndarray of shape (n_samples, n_features)
             Parameters for which to estimate the constraint function value.
 
         Returns
@@ -216,7 +216,7 @@ class ConstraintModel:
 
         Parameters
         ----------
-        constraint_values : np.ndarray of shape (n_samples, n_constraints)
+        constraint_values: np.ndarray of shape (n_samples, n_constraints)
             The values of the constraint function.
 
 

--- a/bayes_opt/domain_reduction.py
+++ b/bayes_opt/domain_reduction.py
@@ -39,16 +39,16 @@ class SequentialDomainReductionTransformer(DomainTransformer):
 
     Parameters
     ----------
-    gamma_osc : float, default=0.7
+    gamma_osc: float, default=0.7
         Parameter used to scale (typically dampen) oscillations.
 
-    gamma_pan : float, default=1.0
+    gamma_pan: float, default=1.0
         Parameter used to scale (typically unitary) panning.
 
-    eta : float, default=0.9
+    eta: float, default=0.9
         Zooming parameter used to shrink the region of interest.
 
-    minimum_window : float or np.ndarray or dict, default=0.0
+    minimum_window: float or np.ndarray or dict, default=0.0
         Minimum window size for each parameter. If a float is provided,
         the same value is used for all parameters.
     """
@@ -75,7 +75,7 @@ class SequentialDomainReductionTransformer(DomainTransformer):
 
         Parameters
         ----------
-        target_space : TargetSpace
+        target_space: TargetSpace
             TargetSpace this DomainTransformer operates on.
         """
         # Set the original bounds
@@ -117,7 +117,7 @@ class SequentialDomainReductionTransformer(DomainTransformer):
 
         Parameters
         ----------
-        target_space : TargetSpace
+        target_space: TargetSpace
             TargetSpace this DomainTransformer operates on.
         """
         # setting the previous
@@ -144,15 +144,15 @@ class SequentialDomainReductionTransformer(DomainTransformer):
 
         Parameters
         ----------
-        new_bounds : np.ndarray
+        new_bounds: np.ndarray
             The proposed new_bounds that (may) need adjustment.
 
-        global_bounds : np.ndarray
+        global_bounds: np.ndarray
             The maximum allowable bounds for each parameter.
 
         Returns
         -------
-        new_bounds : np.ndarray
+        new_bounds: np.ndarray
             The adjusted bounds after enforcing constraints.
         """
         # sort bounds
@@ -227,7 +227,7 @@ class SequentialDomainReductionTransformer(DomainTransformer):
 
         Parameters
         ----------
-        global_bounds : np.ndarray
+        global_bounds: np.ndarray
             The maximum allowable bounds for each parameter.
 
         Raises
@@ -246,10 +246,10 @@ class SequentialDomainReductionTransformer(DomainTransformer):
 
         Parameters
         ----------
-        parameters : dict
+        parameters: dict
             The parameters for which to create the bounds.
 
-        bounds : np.ndarray
+        bounds: np.ndarray
             The bounds for each parameter.
         """
         return {param: bounds[i, :] for i, param in enumerate(parameters)}
@@ -259,7 +259,7 @@ class SequentialDomainReductionTransformer(DomainTransformer):
 
         Parameters
         ----------
-        target_space : TargetSpace
+        target_space: TargetSpace
             TargetSpace this DomainTransformer operates on.
 
         Returns

--- a/bayes_opt/logger.py
+++ b/bayes_opt/logger.py
@@ -21,10 +21,10 @@ def _get_default_logger(verbose, is_constrained):
 
     Parameters
     ----------
-    verbose : int
+    verbose: int
         Verbosity level of the logger.
 
-    is_constrained : bool
+    is_constrained: bool
         Whether the underlying optimizer uses constraints (this requires
         an additional column in the output).
 
@@ -42,10 +42,10 @@ class ScreenLogger(_Tracker):
 
     Parameters
     ----------
-    verbose : int
+    verbose: int
         Verbosity level of the logger.
 
-    is_constrained : bool
+    is_constrained: bool
         Whether the logger is associated with a constrained optimization
         instance.
     """
@@ -73,7 +73,7 @@ class ScreenLogger(_Tracker):
 
         Parameters
         ----------
-        v : int
+        v: int
             New verbosity level of the logger.
         """
         self._verbose = v
@@ -88,7 +88,7 @@ class ScreenLogger(_Tracker):
 
         Parameters
         ----------
-        x : number
+        x: number
             Value to format.
 
         Returns
@@ -111,7 +111,7 @@ class ScreenLogger(_Tracker):
 
         Parameters
         ----------
-        x : boolean
+        x: boolean
             Value to format.
 
         Returns
@@ -126,7 +126,7 @@ class ScreenLogger(_Tracker):
 
         Parameters
         ----------
-        key : string
+        key: string
             Value to format.
 
         Returns
@@ -143,7 +143,7 @@ class ScreenLogger(_Tracker):
 
         Parameters
         ----------
-        instance : bayesian_optimization.BayesianOptimization
+        instance: bayesian_optimization.BayesianOptimization
             The instance associated with the event.
 
         colour :
@@ -170,7 +170,7 @@ class ScreenLogger(_Tracker):
 
         Parameters
         ----------
-        instance : bayesian_optimization.BayesianOptimization
+        instance: bayesian_optimization.BayesianOptimization
             The instance associated with the header.
 
         Returns
@@ -195,7 +195,7 @@ class ScreenLogger(_Tracker):
 
         Parameters
         ----------
-        instance : bayesian_optimization.BayesianOptimization
+        instance: bayesian_optimization.BayesianOptimization
             The instance associated with the step.
 
         Returns
@@ -216,11 +216,11 @@ class ScreenLogger(_Tracker):
 
         Parameters
         ----------
-        event : str
+        event: str
             One of the values associated with `Events.OPTIMIZATION_START`,
             `Events.OPTIMIZATION_STEP` or `Events.OPTIMIZATION_END`.
 
-        instance : bayesian_optimization.BayesianOptimization
+        instance: bayesian_optimization.BayesianOptimization
             The instance associated with the step.
         """
         if event == Events.OPTIMIZATION_START:
@@ -248,10 +248,10 @@ class JSONLogger(_Tracker):
 
     Parameters
     ----------
-    path : str or bytes or os.PathLike
+    path: str or bytes or os.PathLike
         Path to the file to write to.
 
-    reset : bool
+    reset: bool
         Whether to overwrite the file if it already exists.
 
     """
@@ -269,11 +269,11 @@ class JSONLogger(_Tracker):
 
         Parameters
         ----------
-        event : str
+        event: str
             One of the values associated with `Events.OPTIMIZATION_START`,
             `Events.OPTIMIZATION_STEP` or `Events.OPTIMIZATION_END`.
 
-        instance : bayesian_optimization.BayesianOptimization
+        instance: bayesian_optimization.BayesianOptimization
             The instance associated with the step.
 
         """

--- a/bayes_opt/observer.py
+++ b/bayes_opt/observer.py
@@ -24,11 +24,11 @@ class _Tracker:
 
         Parameters
         ----------
-        event : str
+        event: str
             One of the values associated with `Events.OPTIMIZATION_START`,
             `Events.OPTIMIZATION_STEP` or `Events.OPTIMIZATION_END`.
 
-        instance : bayesian_optimization.BayesianOptimization
+        instance: bayesian_optimization.BayesianOptimization
             The instance associated with the step.
         """
         if event == Events.OPTIMIZATION_STEP:

--- a/bayes_opt/target_space.py
+++ b/bayes_opt/target_space.py
@@ -22,14 +22,14 @@ class TargetSpace:
 
     Parameters
     ----------
-    target_func : function
+    target_func: function
         Function to be maximized.
 
-    pbounds : dict
+    pbounds: dict
         Dictionary with parameters names as keys and a tuple with minimum
         and maximum values.
 
-    random_state : int, RandomState, or None
+    random_state: int, RandomState, or None
         optionally specify a seed for a random number generator
 
     allow_duplicate_points: bool, optional (default=False)
@@ -219,7 +219,7 @@ class TargetSpace:
 
         Parameters
         ----------
-        params : dict
+        params: dict
             a single point, with len(x) == self.dim.
 
         Returns
@@ -240,7 +240,7 @@ class TargetSpace:
 
         Parameters
         ----------
-        x : np.ndarray
+        x: np.ndarray
             a single point, with len(x) == self.dim.
 
         Returns
@@ -276,13 +276,13 @@ class TargetSpace:
 
         Parameters
         ----------
-        params : np.ndarray
+        params: np.ndarray
             a single point, with len(x) == self.dim.
 
-        target : float
+        target: float
             target function value
 
-        constraint_value : float or None
+        constraint_value: float or None
             Constraint function value
 
         Raises
@@ -363,12 +363,12 @@ class TargetSpace:
 
         Parameters
         ----------
-        params : np.ndarray
+        params: np.ndarray
             a single point, with len(x) == self.dim
 
         Returns
         -------
-        result : float | Tuple(float, float)
+        result: float | Tuple(float, float)
             target function value, or Tuple(target function value, constraint value)
 
         Example
@@ -504,7 +504,7 @@ class TargetSpace:
 
         Parameters
         ----------
-        new_bounds : dict
+        new_bounds: dict
             A dictionary with the parameter name and its new bounds
         """
         for row, key in enumerate(self.keys):

--- a/bayes_opt/util.py
+++ b/bayes_opt/util.py
@@ -29,10 +29,10 @@ def load_logs(optimizer, logs):
 
     Parameters
     ----------
-    optimizer : BayesianOptimizer
+    optimizer: BayesianOptimizer
         Optimizer the register the previous observations with.
 
-    logs : str or bytes or os.PathLike
+    logs: str or bytes or os.PathLike
         File to load the logs from.
 
     Returns
@@ -69,7 +69,7 @@ def ensure_rng(random_state=None):
 
     Parameters
     ----------
-    random_state : np.random.RandomState or int or None, default=None
+    random_state: np.random.RandomState or int or None, default=None
         Random state to use. if `None`, will create an unseeded random state.
         If `int`, creates a state using the argument as seed. If a
         `np.random.RandomState` simply returns the argument.


### PR DESCRIPTION
related: #509 (especially https://github.com/bayesian-optimization/BayesianOptimization/pull/509#issuecomment-2253749844)
reproduce: ```find bayes_opt -type f -name "*.py" | xargs sed -i '' 's/ : /: /g'```

It would be nice if this could be enforced by a `ruff` or `pydocstyle` rule, but I haven't found a way.