### PR TITLE
`contents: write` permission for versions workflow

### DIFF
--- a/.github/workflows/build_docs.yml
+++ b/.github/workflows/build_docs.yml
@@ -66,6 +66,8 @@ jobs:
     needs: build-docs-and-publish
     if: needs.build-docs-and-publish.outputs.docs-target != ''
     runs-on: Ubuntu-latest
+    permissions:
+      contents: write
     steps:
     - uses: actions/checkout@v3
       with:


### PR DESCRIPTION
this allows the actions permissions to not include `write` by default