### PR TITLE
Apply PEP561

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,10 +5,7 @@ description = "Bayesian Optimization package"
 authors = ["Fernando Nogueira"]
 license = "MIT"
 readme = "README.md"
-packages = [
-    {include = "bayes_opt"},
-    {include = "bayes_opt/py.typed"},
-]
+packages = [{include = "bayes_opt"}]
 
 [tool.poetry.dependencies]
 python = "^3.9"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,10 @@ description = "Bayesian Optimization package"
 authors = ["Fernando Nogueira"]
 license = "MIT"
 readme = "README.md"
-packages = [{include = "bayes_opt"}]
+packages = [
+    {include = "bayes_opt"},
+    {include = "bayes_opt/py.typed"},
+]
 
 [tool.poetry.dependencies]
 python = "^3.9"


### PR DESCRIPTION
closes: #493 
PEP561: https://peps.python.org/pep-0561/

Based on the previous discussion, type hinting using `TypeVar` was ruled out as it would be a barrier to entry for casual users. Instead, #507  was merged in.

In my opinion, this library fully meets the needs of the existing contributors and users, 
so it makes sense to add `py.typed` to let users know that this library provides sufficient type hints.