### PR TITLE
chore: bump ruff

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,4 +6,4 @@ repos:
         name: ruff-format
         args: [--check]
     repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.6.5
+    rev: v0.6.6

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,12 +2,8 @@ repos:
   - hooks:
       - id: ruff
         name: ruff-lint
-    repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.5.2
-
-  - hooks:
       - id: ruff-format
         name: ruff-format
         args: [--check]
     repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.5.2
+    rev: v0.6.5

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ optional = true
 pytest = "^8.0.0"
 pytest-cov = "^4.1.0"
 coverage = "^7.4.1"
-ruff = "0.6.5"
+ruff = "0.6.6"
 pre-commit = "^3.7.1"
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ optional = true
 pytest = "^8.0.0"
 pytest-cov = "^4.1.0"
 coverage = "^7.4.1"
-ruff = "0.5.2"
+ruff = "0.6.5"
 pre-commit = "^3.7.1"
 
 

--- a/tests/test_acquisition.py
+++ b/tests/test_acquisition.py
@@ -12,27 +12,27 @@ from bayes_opt.constraint import ConstraintModel
 from bayes_opt.target_space import TargetSpace
 
 
-@pytest.fixture()
+@pytest.fixture
 def target_func():
     return lambda x: sum(x)
 
 
-@pytest.fixture()
+@pytest.fixture
 def random_state():
     return np.random.RandomState()
 
 
-@pytest.fixture()
+@pytest.fixture
 def gp(random_state):
     return GaussianProcessRegressor(random_state=random_state)
 
 
-@pytest.fixture()
+@pytest.fixture
 def target_space(target_func):
     return TargetSpace(target_func=target_func, pbounds={"x": (1, 4), "y": (0, 3.0)})
 
 
-@pytest.fixture()
+@pytest.fixture
 def constrained_target_space(target_func):
     constraint_model = ConstraintModel(fun=lambda params: params["x"] + params["y"], lb=0.0, ub=1.0)
     return TargetSpace(

--- a/tests/test_constraint.py
+++ b/tests/test_constraint.py
@@ -7,12 +7,12 @@ from scipy.optimize import NonlinearConstraint
 from bayes_opt import BayesianOptimization, ConstraintModel
 
 
-@pytest.fixture()
+@pytest.fixture
 def target_function():
     return lambda x, y: np.cos(2 * x) * np.cos(y) + np.sin(x)
 
 
-@pytest.fixture()
+@pytest.fixture
 def constraint_function():
     return lambda x, y: np.cos(x) * np.cos(y) - np.sin(x) * np.sin(y)
 


### PR DESCRIPTION
Bump the version of `ruff` from `0.5.2` to `0.6.6`.
And fix the `PT001` error.

> The default behavior of `PT001` has changed from `0.6.0`.
> see more: https://github.com/astral-sh/ruff/pull/12106