### PR TITLE
Fix min window type check

### DIFF
--- a/bayes_opt/domain_reduction.py
+++ b/bayes_opt/domain_reduction.py
@@ -8,6 +8,7 @@ simple domain reduction scheme for simulation-based optimization"
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
+from collections.abc import Iterable, Mapping, Sequence
 from typing import TYPE_CHECKING, Any
 from warnings import warn
 
@@ -16,8 +17,6 @@ import numpy as np
 from bayes_opt.target_space import TargetSpace
 
 if TYPE_CHECKING:
-    from collections.abc import Iterable, Mapping, Sequence
-
     from numpy.typing import NDArray
 
     Float = np.floating[Any]
@@ -71,7 +70,8 @@ class SequentialDomainReductionTransformer(DomainTransformer):
         self.gamma_osc = gamma_osc
         self.gamma_pan = gamma_pan
         self.eta = eta
-        if isinstance(minimum_window, dict):
+
+        if isinstance(minimum_window, Mapping):
             self.minimum_window_value = [
                 item[1] for item in sorted(minimum_window.items(), key=lambda x: x[0])
             ]

--- a/bayes_opt/domain_reduction.py
+++ b/bayes_opt/domain_reduction.py
@@ -65,13 +65,13 @@ class SequentialDomainReductionTransformer(DomainTransformer):
         gamma_osc: float = 0.7,
         gamma_pan: float = 1.0,
         eta: float = 0.9,
-        minimum_window: NDArray[Float] | Sequence[float] | float | Mapping[str, float] | None = 0.0,
+        minimum_window: NDArray[Float] | Sequence[float] | Mapping[str, float] | float = 0.0,
     ) -> None:
         self.gamma_osc = gamma_osc
         self.gamma_pan = gamma_pan
         self.eta = eta
 
-        self.minimum_window_value: NDArray[Float] | Sequence[float] | float | None
+        self.minimum_window_value: NDArray[Float] | Sequence[float] | float
         if isinstance(minimum_window, Mapping):
             self.minimum_window_value = [
                 item[1] for item in sorted(minimum_window.items(), key=lambda x: x[0])
@@ -91,7 +91,7 @@ class SequentialDomainReductionTransformer(DomainTransformer):
         self.original_bounds = np.copy(target_space.bounds)
         self.bounds = [self.original_bounds]
 
-        self.minimum_window: NDArray[Float] | Sequence[float] | Sequence[None]  # not Sequence[float | None]
+        self.minimum_window: NDArray[Float] | Sequence[float]
         # Set the minimum window to an array of length bounds
         if isinstance(self.minimum_window_value, (Sequence, np.ndarray)):
             if len(self.minimum_window_value) != len(target_space.bounds):

--- a/bayes_opt/domain_reduction.py
+++ b/bayes_opt/domain_reduction.py
@@ -71,6 +71,7 @@ class SequentialDomainReductionTransformer(DomainTransformer):
         self.gamma_pan = gamma_pan
         self.eta = eta
 
+        self.minimum_window_value: NDArray[Float] | Sequence[float] | float | None
         if isinstance(minimum_window, Mapping):
             self.minimum_window_value = [
                 item[1] for item in sorted(minimum_window.items(), key=lambda x: x[0])
@@ -90,6 +91,7 @@ class SequentialDomainReductionTransformer(DomainTransformer):
         self.original_bounds = np.copy(target_space.bounds)
         self.bounds = [self.original_bounds]
 
+        self.minimum_window: NDArray[Float] | Sequence[float] | Sequence[None]  # not Sequence[float | None]
         # Set the minimum window to an array of length bounds
         if isinstance(self.minimum_window_value, (Sequence, np.ndarray)):
             if len(self.minimum_window_value) != len(target_space.bounds):

--- a/bayes_opt/domain_reduction.py
+++ b/bayes_opt/domain_reduction.py
@@ -91,7 +91,7 @@ class SequentialDomainReductionTransformer(DomainTransformer):
         self.bounds = [self.original_bounds]
 
         # Set the minimum window to an array of length bounds
-        if isinstance(self.minimum_window_value, (list, np.ndarray)):
+        if isinstance(self.minimum_window_value, (Sequence, np.ndarray)):
             if len(self.minimum_window_value) != len(target_space.bounds):
                 error_msg = "Length of minimum_window must be the same as the number of parameters"
                 raise ValueError(error_msg)


### PR DESCRIPTION
`minimum_window` should be typechecked using `Mapping`, not `dict`.
Also, `minimum_window_value` should be typechecked using `Sequence`, not `list`.

And I found it while checking it, is it possible for `minimum_window` to be `None`?
The annotation and docstring on `minimum_window` don't match.
Also, there doesn't seem to be any handling for the case where `minimum_window` is `None` in `SequentialDomainReductionTransformer._trim()`.
https://github.com/bayesian-optimization/BayesianOptimization/blob/10ef3be32bd2dd2e9739f430db98a71ae440c4d8/bayes_opt/domain_reduction.py#L211-L212
In my opinion, `typing.Optional` was used to mean `minimum_window` has a default value. https://github.com/bayesian-optimization/BayesianOptimization/blob/a6697aabf590c9c6f3000b55c5195401b37cff98/bayes_opt/domain_reduction.py#L56

So it would be nice to add a process to `__init__` to either not accept `None`, or to convert to the default value when it is `None`.