### PR TITLE
fix(GPHedge): replace list with sequence

### DIFF
--- a/bayes_opt/acquisition.py
+++ b/bayes_opt/acquisition.py
@@ -40,7 +40,7 @@ from bayes_opt.exception import (
 from bayes_opt.target_space import TargetSpace
 
 if TYPE_CHECKING:
-    from collections.abc import Callable
+    from collections.abc import Callable, Sequence
 
     from numpy.typing import NDArray
     from scipy.optimize import OptimizeResult
@@ -912,18 +912,18 @@ class GPHedge(AcquisitionFunction):
 
     Parameters
     ----------
-    base_acquisitions : List[AcquisitionFunction]
-        List of base acquisition functions.
+    base_acquisitions : Sequence[AcquisitionFunction]
+        Sequence of base acquisition functions.
 
     random_state : int, RandomState, default None
         Set the random state for reproducibility.
     """
 
     def __init__(
-        self, base_acquisitions: list[AcquisitionFunction], random_state: int | RandomState | None = None
+        self, base_acquisitions: Sequence[AcquisitionFunction], random_state: int | RandomState | None = None
     ) -> None:
         super().__init__(random_state)
-        self.base_acquisitions = base_acquisitions
+        self.base_acquisitions = list(base_acquisitions)
         self.n_acq = len(self.base_acquisitions)
         self.gains = np.zeros(self.n_acq)
         self.previous_candidates = None


### PR DESCRIPTION
Given the use case below, it seems that `base_acquisitions` in `GPHedge` can have multiple types of `AcquisitionFunction`.
https://github.com/bayesian-optimization/BayesianOptimization/blob/10ef3be32bd2dd2e9739f430db98a71ae440c4d8/tests/test_acquisition.py#L276

However, the type args in `list` are fixed, so they do not allow such a situation. 
Therefore, we need to change to `Sequence`, which allows args with `covariant=True`.
I was going to ignore it because it's related to generics,
but it seemed necessary for the use case you're considering, so I fixed it.

> [!NOTE]  
> This is not a complete description.
> But I think it will help you understand why the error is occurring.

- `list[T: AcquisitionFunction]`: All elements in `list` are `T`.
> correct case: `[UpperConfidenceBound]` does belong to `list[UpperConfidenceBound]`.(Also, `UpperConfidenceBound` is a subclass of `AcquisitionFunction`.)
> error case: `[UpperConfidenceBound, ProbabilityOfImprovement]` does not belong to any of the three sets `list[AcquisitionFunction]`, `list[UpperConfidenceBound]`, or `list[ProbabilityOfImprovement]`.
- `Sequence[T_co: AcquisitionFunction]`:  Every element in `Sequence` is either `T_co` or a subclass of `T_co`. 
> `[UpperConfidenceBound, ProbabilityOfImprovement]` does not belong to `Sequence[UpperConfidenceBound]` or `Sequence[ProbabilityOfImprovement]`, but it does belong to `Sequence[AcquisitionFunction]`.
