### PR TITLE
upgrade poetry2.0 & apply pep621

### DIFF
--- a/.github/workflows/build_docs.yml
+++ b/.github/workflows/build_docs.yml
@@ -26,13 +26,10 @@ jobs:
         uses: olegtarasov/get-tag@v2.1
       - name: Install pandoc
         run: sudo apt-get install -y pandoc
-      - name: Install the latest version of uv
-        uses: astral-sh/setup-uv@v5
-        with:
-          version: "latest"
       - name: Install Poetry
-        run: |
-          uv tool install poetry
+        uses: snok/install-poetry@v1
+        with:
+          version: 'latest'
       - name: Install package and test dependencies
         run: |
           poetry install --with dev,nbtools

--- a/.github/workflows/build_docs.yml
+++ b/.github/workflows/build_docs.yml
@@ -26,8 +26,13 @@ jobs:
         uses: olegtarasov/get-tag@v2.1
       - name: Install pandoc
         run: sudo apt-get install -y pandoc
+      - name: Install the latest version of uv
+        uses: astral-sh/setup-uv@v5
+        with:
+          version: "latest"
       - name: Install Poetry
-        uses: snok/install-poetry@v1
+        run: |
+          uv tool install poetry
       - name: Install package and test dependencies
         run: |
           poetry install --with dev,nbtools

--- a/.github/workflows/format_and_lint.yml
+++ b/.github/workflows/format_and_lint.yml
@@ -17,13 +17,10 @@ jobs:
       uses: actions/setup-python@v3
       with:
         python-version: "3.9"
-    - name: Install the latest version of uv
-      uses: astral-sh/setup-uv@v5
-      with:
-        version: "latest"
     - name: Install Poetry
-      run: |
-        uv tool install poetry
+      uses: snok/install-poetry@v1
+      with:
+        version: 'latest'
     - name: Install dependencies
       run: |
         poetry install --with dev

--- a/.github/workflows/format_and_lint.yml
+++ b/.github/workflows/format_and_lint.yml
@@ -17,8 +17,13 @@ jobs:
       uses: actions/setup-python@v3
       with:
         python-version: "3.9"
+    - name: Install the latest version of uv
+      uses: astral-sh/setup-uv@v5
+      with:
+        version: "latest"
     - name: Install Poetry
-      uses: snok/install-poetry@v1
+      run: |
+        uv tool install poetry
     - name: Install dependencies
       run: |
         poetry install --with dev

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -19,6 +19,9 @@ jobs:
       matrix:
         python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
         numpy-version: [">=1.25,<2", ">=2"]
+        exclude:
+          - python-version: "3.13"
+            numpy-version: ">=1.25,<2" # numpy<2 is not supported on Python 3.13
 
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -26,8 +26,13 @@ jobs:
       uses: actions/setup-python@v3
       with:
         python-version: ${{ matrix.python-version }}
+    - name: Install the latest version of uv
+      uses: astral-sh/setup-uv@v5
+      with:
+        version: "latest"
     - name: Install Poetry
-      uses: snok/install-poetry@v1
+      run: |
+        uv tool install poetry
     - name: Install test dependencies
       run: |
         poetry add "numpy${{ matrix.numpy-version }}"

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -38,8 +38,13 @@ jobs:
         uv tool install poetry
     - name: Install test dependencies
       run: |
-        poetry add "numpy${{ matrix.numpy-version }}"
-        poetry install --with dev,nbtools
+        poetry self add poetry-plugin-export
+        poetry export -f requirements.txt --with dev,nbtools --without-hashes --output requirements-dev.txt
+        echo "numpy${{ matrix.numpy-version }}" >> constraints.txt
+        uv pip compile requirements-dev.txt --output-file requirements.txt \
+          --python-version ${{ matrix.python-version }} \
+          --override constraints.txt
+        poetry run pip install -r requirements.txt
     - name: Test with pytest
       run: |
         poetry run pytest --cov-report xml --cov=bayes_opt/

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -45,6 +45,7 @@ jobs:
           --python-version ${{ matrix.python-version }} \
           --override constraints.txt
         poetry run pip install -r requirements.txt
+        poetry install --only-root
     - name: Test with pytest
       run: |
         poetry run pytest --cov-report xml --cov=bayes_opt/

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -34,8 +34,9 @@ jobs:
       with:
         version: "latest"
     - name: Install Poetry
-      run: |
-        uv tool install poetry
+      uses: snok/install-poetry@v1
+      with:
+        version: 'latest'
     - name: Install test dependencies
       run: |
         poetry self add poetry-plugin-export

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,24 +1,35 @@
-[tool.poetry]
+[project]
 name = "bayesian-optimization"
 version = "3.0.0b1"
 description = "Bayesian Optimization package"
-authors = ["Fernando Nogueira"]
-license = "MIT"
+authors = [{ name = "Fernando Nogueira", email = "fmfnogueira@gmail.com" }]
+license = { file = "LICENSE" }
 readme = "README.md"
-packages = [{include = "bayes_opt"}]
-
-[tool.poetry.dependencies]
-python = "^3.9"
-scikit-learn = "^1.0.0"
-numpy = ">=1.25"
-scipy =  [
-    {version = "^1.0.0", python = "<3.13"},
-    {version = "^1.14.1", python = ">=3.13"}
+requires-python = ">=3.9,<4.0"
+classifiers = [
+    "License :: OSI Approved :: MIT License",
+    "Programming Language :: Python",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.9",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
 ]
-colorama = "^0.4.6"
+dependencies = [
+    "scikit-learn>=1.0.0,<2.0.0",
+    "numpy>=1.25",
+    "scipy>=1.0.0,<2.0.0; python_version<'3.13'",
+    "scipy>=1.14.1,<2.0.0; python_version>='3.13'",
+    "colorama>=0.4.6,<1.0.0",
+]
+
+[tool.poetry]
+requires-poetry = ">=2.0"
+packages = [{ include = "bayes_opt" }]
 
 
-[tool.poetry.group.dev]  # for testing/developing
+[tool.poetry.group.dev] # for testing/developing
 optional = true
 [tool.poetry.group.dev.dependencies]
 pytest = "^8.0.0"
@@ -28,7 +39,7 @@ ruff = "0.6.6"
 pre-commit = "^3.7.1"
 
 
-[tool.poetry.group.nbtools]  # for running/converting notebooks
+[tool.poetry.group.nbtools] # for running/converting notebooks
 optional = true
 [tool.poetry.group.nbtools.dependencies]
 nbformat = "^5.9.2"
@@ -38,17 +49,17 @@ matplotlib = "^3.0"
 nbsphinx = "^0.9.4"
 sphinx-immaterial = "^0.12.0"
 sphinx = [
-    {version = "^7.0.0", python = "<3.10"},
-    {version = "^8.0.0", python = ">=3.10"}
+    { version = "^7.0.0", python = "<3.10" },
+    { version = "^8.0.0", python = ">=3.10" },
 ]
 sphinx-autodoc-typehints = [
-    {version = "^2.3.0", python = "<3.10"},
-    {version = "^2.4.0", python = ">=3.10"}
+    { version = "^2.3.0", python = "<3.10" },
+    { version = "^2.4.0", python = ">=3.10" },
 ]
 
 
 [build-system]
-requires = ["poetry-core"]
+requires = ["poetry-core>=2.0"]
 build-backend = "poetry.core.masonry.api"
 
 [tool.coverage.report]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,8 @@ classifiers = [
 ]
 dependencies = [
     "scikit-learn>=1.0.0,<2.0.0",
-    "numpy>=1.25",
+    "numpy>=1.25; python_version<'3.13'",
+    "numpy>=2.1.3; python_version>='3.13'",
     "scipy>=1.0.0,<2.0.0; python_version<'3.13'",
     "scipy>=1.14.1,<2.0.0; python_version>='3.13'",
     "colorama>=0.4.6,<1.0.0",


### PR DESCRIPTION
What's different in poetry2.0: [Announcing Poetry 2.0.0](https://python-poetry.org/blog/announcing-poetry-2.0.0/)

Since poetry2.0 now supports pep621, I was able to modify pyproject.toml to conform to the standard spec.
(I kept the modifications to a minimum).
(Since [install-poetry](https://github.com/snok/install-poetry) doesn't support poetry2.0, I've changed how to install poetry from github action. https://github.com/snok/install-poetry/issues/164)

However, it does not yet support pep735 (dependency groups), so the proprietary specification `tool.poetry.group` is retained.
However, this too will be fixed in the future. https://github.com/python-poetry/poetry/issues/9751

If we use poetry in the future, it seems like a good idea to upgrade poetry to 2.0 if possible, as all improvements will only be for 2.0 or later.