### PR TITLE
Update Ubuntu runner for build_docs.yml

### DIFF
--- a/.github/workflows/build_docs.yml
+++ b/.github/workflows/build_docs.yml
@@ -13,7 +13,7 @@ concurrency:
 
 jobs:
   build-docs-and-publish:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     permissions:
       contents: write
     steps:


### PR DESCRIPTION
Ubuntu 20.04 LTS runner was removed on 2025-04-15. Switching to `latest`, which mirrors the setup of the other workflows.