### PR TITLE
add alternative termination criteria

### DIFF
--- a/tests/test_bayesian_optimization.py
+++ b/tests/test_bayesian_optimization.py
@@ -1,8 +1,10 @@
 from __future__ import annotations
 
+from datetime import datetime
 import pickle
 from pathlib import Path
 
+from _pytest.tmpdir import tmp_path
 import numpy as np
 import pytest
 from scipy.optimize import NonlinearConstraint
@@ -585,3 +587,71 @@ def test_save_load_w_custom_parameter(tmp_path):
         suggestion1 = optimizer.suggest()
         suggestion2 = new_optimizer.suggest()
         np.testing.assert_array_almost_equal(suggestion1["sides"], suggestion2["sides"], decimal=7)
+
+
+def test_termination_criteria(tmp_path):
+    """Test each termination criteria individually."""
+
+    def target_func_trivial():
+        # Max at 0, 1
+        return lambda x, y: -(x**2) - ((y - 1) ** 2)
+
+    termination_criteria = {"iterations": 10}
+    pbounds = {"x": [-10.0, 10.0], "y": [-10.0, 10.0]}
+    opt = BayesianOptimization(
+        f=target_func_trivial(), pbounds=pbounds, termination_criteria=termination_criteria
+    )
+
+    # Ensure no initial points are specified.
+    opt.maximize(init_points=0, n_iter=10)
+
+    assert len(opt.res) == termination_criteria["iterations"]
+
+    # Provide reasonable target value for objective fn
+    termination_criteria = {"value": -0.05}
+    opt = BayesianOptimization(
+        f=target_func_trivial(), pbounds=pbounds, termination_criteria=termination_criteria
+    )
+
+    # Call with large number of iterations, so that this is not the termination criteria
+    opt.maximize(init_points=5, n_iter=1_000)
+
+    assert opt.max["target"] > termination_criteria["value"]
+
+    # 3 seconds of maximizing before termination
+    termination_criteria = {"time": {"seconds": 3}}
+    opt = BayesianOptimization(
+        f=target_func_trivial(), pbounds=pbounds, termination_criteria=termination_criteria
+    )
+
+    start = datetime.now()
+    # Call with large number of iterations, so that this is not the termination criteria
+    opt.maximize(n_iter=1_000, init_points=1)
+
+    # Allow ~200ms tolerance on timing
+    assert abs((datetime.now() - start).total_seconds() - termination_criteria["time"]["seconds"]) < 0.2
+
+    # Terminate if no improvement in last 3 iterations
+    termination_criteria = {"convergence_tol": {"n_iters": 3, "abs_tol": 0}}
+
+    opt = BayesianOptimization(
+        f=target_func_trivial(), pbounds=pbounds, termination_criteria=termination_criteria
+    )
+    # Call with number of iterations which will not lead to termination criteria on iterations
+    opt.maximize(n_iter=1_000, init_points=5)
+
+    # Check that none of the last 3 values are the maximum
+    no_improvement_in_3 = all([value < opt._space.max()["target"] for value in opt._space.target[-3:]])
+    assert no_improvement_in_3
+
+    # Converged if minimum improvement below 1 in last 10 iterations
+    termination_criteria = {"convergence_tol": {"n_iters": 10, "abs_tol": 1}}
+
+    opt = BayesianOptimization(
+        f=target_func_trivial(), pbounds=pbounds, termination_criteria=termination_criteria
+    )
+    opt.maximize(n_iter=1_000, init_points=5)
+
+    improvement_below_tol = np.max(opt._space.target[-10:] - opt._space.max()["target"]) < 1
+
+    assert improvement_below_tol


### PR DESCRIPTION
This is a WIP attempt to satisfy some of the goals in this issue thread about adding alternative (not just iteration based) termination criteria for the optimizer: https://github.com/bayesian-optimization/BayesianOptimization/issues/381

New termination criteria are:

- value of the user-defined function
- time taken to run the full optimization process
- absolute tolerance of the improvement in function value

I've added tests to make sure these are functional. The "time taken" one is challenging as this depends on the user's machine (the old "it works on my machine" excuse), but is empirically accurate to within about 200ms for low complexity target/acquisition functions 

Open to any criticism/suggestions here, I am sure the code could be improved but am not sure on the best way to go about it.